### PR TITLE
Log missing component's assets

### DIFF
--- a/app/assets/javascripts/mountain_view.js.erb
+++ b/app/assets/javascripts/mountain_view.js.erb
@@ -2,7 +2,14 @@
   <% depend_on Rails.root.join('app', 'components').to_s %>
   <% Dir.glob(Rails.root.join('app', 'components', '*')).each do |component_dir|
     component = File.basename component_dir
-    require_asset "#{component}/#{component}"
+    begin
+      require_asset "#{component}/#{component}"
+    rescue Sprockets::FileNotFound
+      Rails.logger.debug("MountainView: javascript not found for component '#{component}'")
+  %>
+/* MountainView: javascript not found for component '<%= component %>' */
+  <%
+    end
   end %>
 <% else %>
   <% depend_on Rails.root.join('app').to_s %>

--- a/app/assets/stylesheets/mountain_view.css.erb
+++ b/app/assets/stylesheets/mountain_view.css.erb
@@ -2,7 +2,14 @@
   <% depend_on Rails.root.join('app', 'components').to_s %>
   <% Dir.glob(Rails.root.join('app', 'components', '*')).each do |component_dir|
     component = File.basename component_dir
-    require_asset "#{component}/#{component}"
+    begin
+      require_asset "#{component}/#{component}"
+    rescue Sprockets::FileNotFound
+      Rails.logger.debug("MountainView: stylesheet not found for component '#{component}'")
+  %>
+/* MountainView: stylesheet not found for component '<%= component %>' */
+  <%
+    end
   end %>
 <% else %>
   <% depend_on Rails.root.join('app').to_s %>

--- a/test/dummy/app/components/paragraph/_paragraph.html.erb
+++ b/test/dummy/app/components/paragraph/_paragraph.html.erb
@@ -1,0 +1,1 @@
+<%= simple_format properties[:text] %>

--- a/test/mountain_view_test.rb
+++ b/test/mountain_view_test.rb
@@ -12,7 +12,8 @@ class MountainViewTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_match(/\.header {/, response.body)
-    refute_match(/FileNotFound/, response.body)
+    refute_match(/Sprockets::FileNotFound/, response.body)
+    assert_match(/MountainView: stylesheet not found for component 'paragraph'/, response.body)
   end
 
   test "javascripts are properly served" do
@@ -20,7 +21,8 @@ class MountainViewTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_match(/console\.log\("header"\)/, response.body)
-    refute_match(/FileNotFound/, response.body)
+    refute_match(/Sprockets::FileNotFound/, response.body)
+    assert_match(/MountainView: javascript not found for component 'paragraph'/, response.body)
   end
 
   test "shows styleguide" do


### PR DESCRIPTION
Rescue missing assets exceptions and log them both to the Rails log and
as a comment in the final asset file.

Closes #13