### PR TITLE
make components path configurable

### DIFF
--- a/app/assets/javascripts/mountain_view.js.erb
+++ b/app/assets/javascripts/mountain_view.js.erb
@@ -1,6 +1,6 @@
-<% if Dir.exists?(Rails.root.join("app", "components") ) %>
-  <% depend_on Rails.root.join('app', 'components').to_s %>
-  <% Dir.glob(Rails.root.join('app', 'components', '*')).each do |component_dir|
+<% if Dir.exists?(MountainView.configuration.components_path) %>
+  <% depend_on MountainView.configuration.components_path.to_s %>
+  <% Dir.glob(MountainView.configuration.components_path.join('*')).each do |component_dir|
     component = File.basename component_dir
     begin
       require_asset "#{component}/#{component}"

--- a/app/assets/stylesheets/mountain_view.css.erb
+++ b/app/assets/stylesheets/mountain_view.css.erb
@@ -1,9 +1,9 @@
 <% MountainView.configuration.included_stylesheets.each do |included_stylesheet| %>
   <%= require_asset included_stylesheet %>
 <% end %>
-<% if Dir.exists?(Rails.root.join("app", "components") ) %>
-  <% depend_on Rails.root.join('app', 'components').to_s %>
-  <% Dir.glob(Rails.root.join('app', 'components', '*')).each do |component_dir|
+<% if Dir.exists?(MountainView.configuration.components_path) %>
+  <% depend_on MountainView.configuration.components_path.to_s %>
+  <% Dir.glob(MountainView.configuration.components_path.join('*')).each do |component_dir|
     component = File.basename component_dir
     begin
       require_asset "#{component}/#{component}"

--- a/app/helpers/mountain_view/styleguide_helper.rb
+++ b/app/helpers/mountain_view/styleguide_helper.rb
@@ -1,7 +1,7 @@
 module MountainView
   module StyleguideHelper
     def mv_components
-      Dir.glob(Rails.root.join("app", "components", "*")).map do |component_dir|
+      Dir.glob(MountainView.configuration.components_path.join("*")).map do |component_dir|
         MountainView::Component.new File.basename(component_dir)
       end
     end

--- a/app/helpers/mountain_view/styleguide_helper.rb
+++ b/app/helpers/mountain_view/styleguide_helper.rb
@@ -1,7 +1,8 @@
 module MountainView
   module StyleguideHelper
     def mv_components
-      Dir.glob(MountainView.configuration.components_path.join("*")).map do |component_dir|
+      component_dirs = MountainView.configuration.components_path.join("*")
+      Dir.glob(component_dirs).map do |component_dir|
         MountainView::Component.new File.basename(component_dir)
       end
     end

--- a/lib/mountain_view.rb
+++ b/lib/mountain_view.rb
@@ -1,6 +1,5 @@
 require "mountain_view/version"
 require "mountain_view/configuration"
-require 'mountain_view/engine' if defined?(Rails)
 
 module MountainView
   def self.configuration
@@ -11,3 +10,5 @@ module MountainView
     yield(configuration)
   end
 end
+
+require 'mountain_view/engine' if defined?(Rails)

--- a/lib/mountain_view.rb
+++ b/lib/mountain_view.rb
@@ -11,4 +11,4 @@ module MountainView
   end
 end
 
-require 'mountain_view/engine' if defined?(Rails)
+require "mountain_view/engine" if defined?(Rails)

--- a/lib/mountain_view/component.rb
+++ b/lib/mountain_view/component.rb
@@ -15,7 +15,7 @@ module MountainView
     end
 
     def stubs_file
-      Rails.root.join("app/components/#{name}/#{name}.yml")
+      MountainView.configuration.components_path.join(name, "#{name}.yml")
     end
 
     def stubs?

--- a/lib/mountain_view/configuration.rb
+++ b/lib/mountain_view/configuration.rb
@@ -1,6 +1,7 @@
 module MountainView
   class Configuration
-    attr_accessor :included_stylesheets, :components_path
+    attr_accessor :included_stylesheets
+    attr_reader :components_path
 
     def initialize
       @included_stylesheets = []

--- a/lib/mountain_view/configuration.rb
+++ b/lib/mountain_view/configuration.rb
@@ -1,9 +1,13 @@
 module MountainView
   class Configuration
-    attr_accessor :included_stylesheets
+    attr_accessor :included_stylesheets, :components_path
 
     def initialize
       @included_stylesheets = []
+    end
+
+    def components_path=(path)
+      @components_path = Pathname.new(path)
     end
   end
 end

--- a/lib/mountain_view/engine.rb
+++ b/lib/mountain_view/engine.rb
@@ -6,15 +6,21 @@ module MountainView
   class Engine < ::Rails::Engine
     isolate_namespace MountainView
 
+    initializer 'mountain_view.components_path' do |app|
+      MountainView.configure do |c|
+        c.components_path ||= app.root.join('app', 'components')
+      end
+    end
+
     initializer "mountain_view.assets" do |app|
-      Rails.application.config.assets.paths << app.root.join("app", "components")
+      Rails.application.config.assets.paths << MountainView.configuration.components_path
       Rails.application.config.assets.precompile += %w( mountain_view/styleguide.css
                                                         mountain_view/styleguide.js )
     end
 
     initializer "mountain_view.append_view_paths" do |app|
       ActiveSupport.on_load :action_controller do
-        append_view_path app.root.join("app", "components")
+        append_view_path MountainView.configuration.components_path
       end
     end
 

--- a/lib/mountain_view/engine.rb
+++ b/lib/mountain_view/engine.rb
@@ -6,14 +6,15 @@ module MountainView
   class Engine < ::Rails::Engine
     isolate_namespace MountainView
 
-    initializer 'mountain_view.components_path' do |app|
+    initializer "mountain_view.components_path" do |app|
       MountainView.configure do |c|
-        c.components_path ||= app.root.join('app', 'components')
+        c.components_path ||= app.root.join("app", "components")
       end
     end
 
     initializer "mountain_view.assets" do |app|
-      Rails.application.config.assets.paths << MountainView.configuration.components_path
+      Rails.application.config.assets.paths <<
+        MountainView.configuration.components_path
       Rails.application.config.assets.precompile += %w( mountain_view/styleguide.css
                                                         mountain_view/styleguide.js )
     end


### PR DESCRIPTION
we want to use mountain_view inside our own ui_components engine, so we needed the path to the components folder to be configurable. mountain_view should now use this configurable path to locate the components to display in the generated style guide.

please let us know if this is something you would be interested in incorporating, or if you have any other feedback :)