### PR TITLE
Set asset extension to prevent missing requires

### DIFF
--- a/app/assets/javascripts/mountain_view.js.erb
+++ b/app/assets/javascripts/mountain_view.js.erb
@@ -3,7 +3,7 @@
   <% Dir.glob(MountainView.configuration.components_path.join('*')).each do |component_dir|
     component = File.basename component_dir
     begin
-      require_asset "#{component}/#{component}"
+      require_asset "#{component}/#{component}.js"
     rescue Sprockets::FileNotFound
       Rails.logger.debug("MountainView: javascript not found for component '#{component}'")
   %>

--- a/app/assets/stylesheets/mountain_view.css.erb
+++ b/app/assets/stylesheets/mountain_view.css.erb
@@ -6,7 +6,7 @@
   <% Dir.glob(MountainView.configuration.components_path.join('*')).each do |component_dir|
     component = File.basename component_dir
     begin
-      require_asset "#{component}/#{component}"
+      require_asset "#{component}/#{component}.css"
     rescue Sprockets::FileNotFound
       Rails.logger.debug("MountainView: stylesheet not found for component '#{component}'")
   %>


### PR DESCRIPTION
This fixes some odd behaviour where stylesheets or javascripts were not included in the document. Only affected some assets (one JS file in my testing), but I believe this also relates to https://github.com/jgnatch/mountain_view/issues/25. Tested with various extensions  - `sass`, `scss` and `css` all work fine with this setting. 